### PR TITLE
Docker travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+python:
+  - 2.7
+  - 3.5
+
+services:
+  - docker
+
+env:
+  DOCKER_COMPOSE_VERSION: 1.7.1
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - sudo apt-get update
+  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+
+script:
+  - docker-compose -f docker-compose.yml up -d 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adventurelookup
 
-[![Build Status](https://travis-ci.org/probably-not-a-cat/adventurelookup-backend.svg?branch=master)](https://travis-ci.org/probably-not-a-cat/adventurelookup-backend)
+[![Build Status](https://travis-ci.org/AdventureLookup/adventurelookup-backend.svg?branch=master)](https://travis-ci.org/AdventureLookup/adventurelookup-backend)
 
 A searchable tool, AdventureLookup.com, that will allow Dungeon Masters to find the adventure they're looking for.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # adventurelookup
+
+[![Build Status](https://travis-ci.org/probably-not-a-cat/adventurelookup-backend.svg?branch=master)](https://travis-ci.org/probably-not-a-cat/adventurelookup-backend)
+
 A searchable tool, AdventureLookup.com, that will allow Dungeon Masters to find the adventure they're looking for.
 
 


### PR DESCRIPTION
I was able to test part of the docker-compse build

```
docker-compose -f docker-compose.yml up -d 
```

I had to leave out `-f dev.yml` because it complained that port `5432` was in use. [See this for more detail](https://travis-ci.org/probably-not-a-cat/adventurelookup-backend/jobs/131956231)

Everything in `before_install:` is to get the docker commands to match ours. I guess travis has an older version of Docker preinstalled.
