### PR TITLE
Rename [style] section of setup.cfg to [yapf]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,6 @@ line_length = 79
 multi_line_output = 5
 not_skip = __init__.py
 
-[style]
+[yapf]
 dedent_closing_brackets = true
 column_limit = 119


### PR DESCRIPTION
yapf settings should be in the [style] section of a .style.yapf file, but the [yapf] section of a setup.cfg. From the [docs](https://github.com/google/yapf#formatting-style) (emphasis mine):

> YAPF will search for the formatting style in the following manner:
> 1. Specified on the command line
> 2. In the **[style] section of a .style.yapf file** in either the current directory or one of its parent directories.
> 3. In the **[yapf] secionf (sic) of a setup.cfg file** in either the current directory or one of its parent directories.
> 4. In the ~/.config/yapf/style file in your home directory.

yapf ignored altered max line length until I changed the section name.

This almost seems unworthy of a PR, but hey-ho.
